### PR TITLE
Change the API

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 ---
 name: JoinEffect
 version: 0.1 Dev
-api: 1.12.0
+api: 1.0.0
 author: TonyDroidd
 main: TDroidd\JoinEffect\Main
 description: Allows players to receive an effect when they join to server.


### PR DESCRIPTION
The API wasn't loading correctly at start, this is because that you aren't using the correct api version. You will need to configure at 1.0.0 and not 1.12.0. See this for more details: https://github.com/PocketMine/Documentation/wiki/Plugin-Tutorial
